### PR TITLE
Made ve row view scroll only on annotation click

### DIFF
--- a/src/VectorEditor/RowView/index.js
+++ b/src/VectorEditor/RowView/index.js
@@ -266,6 +266,8 @@ class RowView extends React.Component {
       ...props
     };
 
+    const { isDragInProgress } = propsToUse;
+
     var { caretPosition, selectionLayer } = propsToUse;
     var bpsPerRow = getBpsPerRow(propsToUse);
     //UPDATE THE ROW VIEW'S POSITION BASED ON CARET OR SELECTION CHANGES
@@ -291,9 +293,11 @@ class RowView extends React.Component {
       var rowToScrollTo = Math.floor(scrollToBp / bpsPerRow);
       var [start, end] = this.InfiniteScroller.getVisibleRange();
       if (rowToScrollTo < start || rowToScrollTo > end) {
-        this.InfiniteScroller.scrollTo(rowToScrollTo, {
-          jumpToBottomOfRow: scrollToBp > previousBp
-        });
+        if (!isDragInProgress()) {
+          this.InfiniteScroller.scrollTo(rowToScrollTo, {
+            jumpToBottomOfRow: scrollToBp > previousBp
+          });
+        }
       }
     }
   }

--- a/src/VectorEditor/withEditorInteractions/index.js
+++ b/src/VectorEditor/withEditorInteractions/index.js
@@ -1,9 +1,7 @@
 import getSequenceWithinRange from "ve-range-utils/getSequenceWithinRange";
 import Clipboard from "./Clipboard";
-import updateSelectionOrCaret
-  from "../utils/selectionAndCaretUtils/updateSelectionOrCaret";
-import normalizePositionByRangeLength
-  from "ve-range-utils/normalizePositionByRangeLength";
+import updateSelectionOrCaret from "../utils/selectionAndCaretUtils/updateSelectionOrCaret";
+import normalizePositionByRangeLength from "ve-range-utils/normalizePositionByRangeLength";
 import getRangeLength from "ve-range-utils/getRangeLength";
 import React from "react";
 // import draggableClassnames from "../constants/draggableClassnames";
@@ -134,6 +132,7 @@ function VectorInteractionHOC(Component) {
               });
             }
           },
+          isDragInProgress: () => dragInProgress,
           editorDragStopped: function() {
             setTimeout(function() {
               dragInProgress = false;


### PR DESCRIPTION
Having the VE row scroll to the selection when we were selecting was causing the selection process to get laggy. This was due to the time taken to render the rows in the infinite scroller. 

I disabled scrolling during selection. Clicking on annotations still causes the row view to scroll to selection.