### PR TITLE
Fix row expander bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "teselagen-react-components",
-  "version": "22.0.46",
+  "version": "22.0.47",
   "description": "Teselagen React Component Library",
   "main": "lib/index.js",
   "homepage": "http://teselagen.github.io/teselagen-react-components",

--- a/src/DataTable/index.js
+++ b/src/DataTable/index.js
@@ -595,7 +595,7 @@ class ReactDataTable extends React.Component {
     return {
       onClick: e => {
         // if checkboxes are activated or row expander is clicked don't select row
-        if (e.target.classList.contains("tg-expander")) {
+        if (e.target.matches(".tg-expander, .tg-expander *")) {
           reduxFormExpandedEntityIdMap.input.onChange({
             ...reduxFormExpandedEntityIdMap.input.value,
             [rowId]: !isExpanded


### PR DESCRIPTION
connects Teselagen/hde#1193

Previously, it would only work when clicking the button background directly (i.e. not a descendant), so clicking on the arrow itself would not work.
@tnrich @tgreen7 
