### PR TITLE
Set exact library version to avoid a bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "react-addons-pure-render-mixin": "^15.6.0",
     "react-dropzone": "^4.2.9",
     "react-resize-detector": "^2.3.0",
-    "react-rnd": "^7.4.1",
+    "react-rnd": "7.4.1",
     "react-sortable-hoc": "^0.6.8",
     "recompose": "^0.26.0",
     "redux": "^3.7.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8462,7 +8462,7 @@ react-resize-detector@^2.3.0:
     prop-types "^15.6.0"
     resize-observer-polyfill "^1.5.0"
 
-react-rnd@^7.4.1:
+react-rnd@7.4.1:
   version "7.4.1"
   resolved "https://registry.yarnpkg.com/react-rnd/-/react-rnd-7.4.1.tgz#8b928d7db590fdc8c8d194ab03388e9fa479c189"
   dependencies:


### PR DESCRIPTION
Set react-rnd to exact version 7.4.1, to avoid eventually getting 7.4.3 which apparently causes issues with forms (unmounts and destroys form state).

Ref. TeselaGen/hde/#1740
@tgreen7 