### PR TITLE
DataTable styling tweaks

### DIFF
--- a/demo/dist/index.html
+++ b/demo/dist/index.html
@@ -4,8 +4,8 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <meta http-equiv="x-ua-compatible" content="ie=edge">
-    <title>teselagen-react-components 22.2.14 Demo</title>
-  <link href="demo.39a40a90.css" rel="stylesheet"></head>
+    <title>teselagen-react-components 22.2.16 Demo</title>
+  <link href="demo.8aef5b82.css" rel="stylesheet"></head>
   <body>
     <div id="demo"></div>
   <script>/******/ (function(modules) { // webpackBootstrap
@@ -101,7 +101,7 @@
 /******/ 		if (__webpack_require__.nc) {
 /******/ 			script.setAttribute("nonce", __webpack_require__.nc);
 /******/ 		}
-/******/ 		script.src = __webpack_require__.p + "" + ({"0":"demo"}[chunkId]||chunkId) + "." + {"0":"713b7d7d"}[chunkId] + ".js";
+/******/ 		script.src = __webpack_require__.p + "" + ({"0":"demo"}[chunkId]||chunkId) + "." + {"0":"7c7319fd"}[chunkId] + ".js";
 /******/ 		var timeout = setTimeout(onScriptComplete, 120000);
 /******/ 		script.onerror = script.onload = onScriptComplete;
 /******/ 		function onScriptComplete() {
@@ -158,5 +158,5 @@
 /******/ })
 /************************************************************************/
 /******/ ([]);</script>
-  <script type="text/javascript" src="demo.713b7d7d.js"></script></body>
+  <script type="text/javascript" src="demo.7c7319fd.js"></script></body>
 </html>

--- a/demo/src/examples/DataTable.js
+++ b/demo/src/examples/DataTable.js
@@ -188,6 +188,9 @@ class DataTableInstance extends React.Component {
       isViewable: true,
       withSearch: true,
       withPaging: true,
+      expandAllByDefault: false,
+      withExpandAndCollapseAllButton: false,
+      selectAllByDefault: false,
       withFilter: true,
       withSort: true,
       withSubComponent: true,
@@ -290,6 +293,9 @@ class DataTableInstance extends React.Component {
         withTitle: false,
         withSearch: false,
         withPaging: false,
+        withExpandAndCollapseAllButton: false,
+        expandAllByDefault: false,
+        selectAllByDefault: false,
         withFilter: false,
         isCopyable: false,
         by default, but they are all 
@@ -308,6 +314,9 @@ class DataTableInstance extends React.Component {
         )}
         {renderToggle(this, "withDisplayOptions")}
         {renderToggle(this, "withPaging")}
+        {renderToggle(this, "withExpandAndCollapseAllButton")}
+        {renderToggle(this, "expandAllByDefault")}
+        {renderToggle(this, "selectAllByDefault")}
         {renderToggle(this, "withFilter")}
         {renderToggle(this, "withSort")}
         {renderToggle(this, "noHeader")}
@@ -405,7 +414,10 @@ class DataTableInstance extends React.Component {
             noSelect={this.state.noSelect}
             isSimple={this.state.isSimple}
             withSearch={this.state.withSearch}
+            withExpandAndCollapseAllButton={this.state.withExpandAndCollapseAllButton}
+            expandAllByDefault={this.state.expandAllByDefault}
             withPaging={this.state.withPaging}
+            selectAllByDefault={this.state.selectAllByDefault}
             withFilter={this.state.withFilter}
             withSort={this.state.withSort}
             noFullscreenButton={this.state.noFullscreenButton}


### PR DESCRIPTION
Here are the changes that hadn't made it to the previous merge.

@tgreen7 
I kept my changes, using a more specific selector instead of using `!important`. Should work fine (and does in my tests) but LMK if you still find any issues

@tnrich 
The `height: 100%` in HDE is so that libraries expand vertically to make use of all available space
(you had asked about that on the previous PR)
Note: I added that in here too, leaving your original comment and adding one saying I'm restoring the rule to see if it still causes problems.
