### PR TITLE
Moves fieldGroup outside of div that was having overflow-x issues that were covering up submenu

### DIFF
--- a/src/DataTable/DisplayOptions.js
+++ b/src/DataTable/DisplayOptions.js
@@ -173,10 +173,10 @@ export default class DisplayOptions extends React.Component {
               <h5 style={{ marginBottom: 10, marginTop: 10 }}>
                 Displayed Columns:
               </h5>
-              <div style={{ maxHeight: 290, overflowY: "auto" }}>
+              <div style={{ maxHeight: 260, overflowY: "auto" }}>
                 {mainFields.map(getFieldCheckbox)}
-                {fieldGroupMenu}
               </div>
+              <div>{fieldGroupMenu}</div>
               {hasOptionForForcedHidden && (
                 <div style={{ marginTop: 15 }}>
                   <Switch


### PR DESCRIPTION
From this:
![Screen Shot 2020-05-22 at 6 18 03 AM](https://user-images.githubusercontent.com/4167907/82662878-4169ce00-9bf4-11ea-8fe4-1a22b663cde9.png)


To this:
![Screen Shot 2020-05-22 at 6 17 21 AM](https://user-images.githubusercontent.com/4167907/82662690-ee901680-9bf3-11ea-91b7-0308aab36c8c.png)
