### PR TITLE
fix overflow of field filter; fix '-' can not be input in numeric input comp

### DIFF
--- a/src/DataTable/FilterAndSortMenu.js
+++ b/src/DataTable/FilterAndSortMenu.js
@@ -182,7 +182,7 @@ class FilterInput extends React.Component {
             <NumericInput
               placeholder="Value"
               onValueChange={function(numVal) {
-                handleFilterValueChange(numVal);
+                handleFilterValueChange(isNaN(numVal) ? 0 : numVal);
               }}
               autoFocus
               {...onEnterHelper(handleFilterSubmit)}
@@ -197,7 +197,10 @@ class FilterInput extends React.Component {
             <NumericInput
               placeholder="Low"
               onValueChange={function(numVal) {
-                handleFilterValueChange([numVal, filterValue[1]]);
+                handleFilterValueChange([
+                  isNaN(numVal) ? 0 : numVal,
+                  filterValue[1]
+                ]);
               }}
               {...onEnterHelper(handleFilterSubmit)}
               value={filterValue && filterValue[0]}
@@ -205,7 +208,10 @@ class FilterInput extends React.Component {
             <NumericInput
               placeholder="High"
               onValueChange={function(numVal) {
-                handleFilterValueChange([filterValue[0], numVal]);
+                handleFilterValueChange([
+                  filterValue[0],
+                  isNaN(numVal) ? 0 : numVal
+                ]);
               }}
               {...onEnterHelper(handleFilterSubmit)}
               value={filterValue && filterValue[1]}

--- a/src/DataTable/index.js
+++ b/src/DataTable/index.js
@@ -1675,7 +1675,7 @@ function ColumnFilterMenu({
       }}
       isOpen={columnFilterMenuOpen}
       modifiers={{
-        preventOverflow: { enabled: false },
+        preventOverflow: { enabled: true },
         hide: { enabled: false },
         flip: { enabled: false }
       }}


### PR DESCRIPTION
The field filter will overflow:
![image](https://user-images.githubusercontent.com/57167230/143517423-c390cada-be05-4704-bf9d-c09987127eb8.png)

If we input a negative operator '-', then 'NaN' will show:
![image](https://user-images.githubusercontent.com/57167230/143517521-b96f934d-f454-4a64-96cb-f882ce74daed.png)
