### PR TITLE
Fix css import when using vite

### DIFF
--- a/src/DataTable/FilterAndSortMenu.js
+++ b/src/DataTable/FilterAndSortMenu.js
@@ -15,6 +15,7 @@ import dayjs from "dayjs";
 import getDayjsFormatter from "../utils/getDayjsFormatter";
 import { onEnterHelper } from "../utils/handlerHelpers";
 import DialogFooter from "../DialogFooter";
+import "@teselagen/react-table/react-table.css";
 import "./style.css";
 import "../toastr";
 

--- a/src/DataTable/index.js
+++ b/src/DataTable/index.js
@@ -72,6 +72,7 @@ import dataTableEnhancer from "./dataTableEnhancer";
 import defaultProps from "./defaultProps";
 
 import "../toastr";
+import "@teselagen/react-table/react-table.css";
 import "./style.css";
 import { getRecordsFromIdMap } from "./utils/withSelectedEntities";
 import { CellDragHandle } from "./CellDragHandle";

--- a/src/DataTable/style.css
+++ b/src/DataTable/style.css
@@ -1,5 +1,3 @@
-@import url(~@teselagen/react-table/react-table.css);
-
 /* DataTable style.css */
 .custom-menu-item {
   text-overflow: ellipsis;

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,6 @@
+import "@blueprintjs/core/lib/css/blueprint.css";
+import "@blueprintjs/datetime/lib/css/blueprint-datetime.css";
+import "@blueprintjs/icons/lib/css/blueprint-icons.css";
 import "./style.css";
 import "./autoTooltip";
 export * from "./AssignDefaultsModeContext";

--- a/src/style.css
+++ b/src/style.css
@@ -1,7 +1,3 @@
-@import url(~@blueprintjs/core/lib/css/blueprint.css);
-@import url(~@blueprintjs/datetime/lib/css/blueprint-datetime.css);
-@import url(~@blueprintjs/icons/lib/css/blueprint-icons.css);
-
 :root {
   --base1: #ffffff;
   --base2: #cdcdcd;


### PR DESCRIPTION
The ~ convention of importing CSS files is only supported by css-loader. Other loaders (sass-loader, less-loader) seems have deprecated this option.

The vite completely does not support it.
Here I am improving the compatibility of this library to vite since using vite to launch a front end during development would be faster.