### PR TITLE
paging input size resizable on input

### DIFF
--- a/src/DataTable/PagingTool.js
+++ b/src/DataTable/PagingTool.js
@@ -7,7 +7,7 @@ import { onEnterOrBlurHelper } from "../utils/handlerHelpers";
 import { defaultPageSizes } from "./utils/queryParams";
 import getIdOrCodeOrIndex from "./utils/getIdOrCodeOrIndex";
 
-function PagingInput({ disabled, onBlur, defaultPage, lastPage }) {
+function PagingInput({ disabled, onBlur, defaultPage }) {
   const [page, setPage] = useState(defaultPage);
   const defaultValue = useRef(defaultPage);
 
@@ -22,7 +22,7 @@ function PagingInput({ disabled, onBlur, defaultPage, lastPage }) {
     <input
       style={{
         marginLeft: 5,
-        width: lastPage > 999 ? 65 : lastPage > 99 ? 45 : 35,
+        width: page > 999 ? 65 : page > 99 ? 45 : 35,
         marginRight: 8
       }}
       value={page}


### PR DESCRIPTION
PagingInput grows depending on how many pages there are in total, instead, according to customer support, it should be easier for the user to be dependant on the number that is written. [issue 340](https://github.com/TeselaGen/customer-support/issues/340)